### PR TITLE
fix(dev): use authn compatibility login flow

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -11,9 +11,10 @@ const webId = document.getElementById('webId')
 loginBanner.appendChild(UI.login.loginStatusBox(document, null, {}))
 
 async function finishLogin () {
-  await authSession.handleIncomingRedirect()
+  await authn.checkUser()
   const session = authSession
-  if (session.info.isLoggedIn) {
+  const isLoggedIn = session?.info?.isLoggedIn ?? session?.isActive ?? Boolean(session?.webId)
+  if (isLoggedIn) {
     // Update the page with the status.
     webId.textContent = 'Logged in as: ' + authn.currentUser().uri
   } else {


### PR DESCRIPTION
Replace direct authSession.handleIncomingRedirect usage with authn.checkUser in the dev entrypoint.\nUse a session-shape-safe logged-in check so both legacy and uvdsl-backed sessions work.